### PR TITLE
Change version metadata to a number to allow easier version compatibility checks

### DIFF
--- a/examples/animation.bimg
+++ b/examples/animation.bimg
@@ -37,7 +37,7 @@
       "ffffffffff",
     },
   },
-  version = "1.0.0",
+  version = 0.1, -- Current pre-release version
   animation = true, -- Important for animations!
   secondsPerFrame = 0.2, -- 0.2 seconds per frame (5FPS) as the default delay between drawing each frame.
   palette = { -- Only defining the colours required, but can define all if needed.

--- a/examples/image.bimg
+++ b/examples/image.bimg
@@ -12,7 +12,7 @@
       "ffffffffff",
     },
   },
-  version = "1.0.0",
+  version = 0.1,
   animation = false,
   palette = { -- Only defining the colours required, but can define all if needed.
     [colors.white] = { 0xffffff },

--- a/rough-ideas.md
+++ b/rough-ideas.md
@@ -9,7 +9,7 @@ Each frame can have a `palette` key to specify a specific palette for that frame
   
 # Metadata
 Metadata is stored at the root of the table.    
-`version`: number Version of the format as `major.minor` where each major version represents a change to the format that may break compatibility with existing software.
+`version`: number Version of the format as `major.minor` where each major version represents a change to the format that may break compatibility with existing software.   
 `animation`: boolean Whether the image is an animation (if so, each frame is numerically indexed).  
 (per frame) `duration`: number Duration of the frame in seconds, overrides `secondsPerFrame` for that frame.  
 `secondsPerFrame`: number Default length of each frame in seconds.  

--- a/rough-ideas.md
+++ b/rough-ideas.md
@@ -9,7 +9,7 @@ Each frame can have a `palette` key to specify a specific palette for that frame
   
 # Metadata
 Metadata is stored at the root of the table.    
-`version`: string Version string of the format.  
+`version`: number Version of the format as `major.minor` where each major version represents a change to the format that may break compatibility with existing software.
 `animation`: boolean Whether the image is an animation (if so, each frame is numerically indexed).  
 (per frame) `duration`: number Duration of the frame in seconds, overrides `secondsPerFrame` for that frame.  
 `secondsPerFrame`: number Default length of each frame in seconds.  


### PR DESCRIPTION
I propose that we change `version` from a string to a number in the format `major.minor` where major versions represent a change in the format that may break compatibility with existing software.

While we're still in the pre-release stage I suggest we start with `0.1` and increment minor with every change to the format until we settle on a release candidate version.